### PR TITLE
pin mkdocs-material dependency to 4.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ brew install python3
 brew install mkdocs
 brew install node
 brew install jq
-pip3 install mkdocs-material
-pip3 install pymdown-extensions
-pip3 install taskcat
+pip3 install -r requirements.txt
 
 npm install -g npm
 npm install -g grunt-cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material==4.6.3
+pymdown-extensions
+taskcat


### PR DESCRIPTION
*Description of changes:*

I get a cryptic error when trying to serve the workshop site locally using mkdocs-material v5, which is the default version that gets installed if you follow the README. This PR pins the mkdocs-material package to a version that is known to work. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.