### PR TITLE
Fix typo on clusterEndpoint & secretClusterMasterUser placeholder

### DIFF
--- a/docs/global/failover/index.md
+++ b/docs/global/failover/index.md
@@ -18,7 +18,7 @@ This lab requires the following prerequisites:
 
 ## 1. Inject a failure in the primary region
 
-If you are not already connected to the Session Manager workstation command line, please connect [following these instructions](/prereqs/connect/) in the **primary region**. Once connected, run the command below, replacing the ==[clusterEndpont]== placeholder with the cluster endpoint of your DB cluster.
+If you are not already connected to the Session Manager workstation command line, please connect [following these instructions](/prereqs/connect/) in the **primary region**. Once connected, run the command below, replacing the ==[clusterEndpoint]== placeholder with the cluster endpoint of your DB cluster.
 
 !!! warning "Region Check"
     Ensure you are still working in the **primary region**, especially if you are the links in this guide to open the service console at the right screen.
@@ -115,7 +115,7 @@ echo "export DBPASS=\"$DBPASS\"" >> /home/ubuntu/.bashrc
 echo "export DBUSER=$DBUSER" >> /home/ubuntu/.bashrc
 ```
 
-Next, run the command below, replacing the ==[newClusterEndpont]== placeholder with the cluster endpoint of your newly promoted DB cluster.
+Next, run the command below, replacing the ==[newClusterEndpoint]== placeholder with the cluster endpoint of your newly promoted DB cluster.
 
 ```shell
 mysql -h[newClusterEndpoint] -u$DBUSER -p"$DBPASS" mylab

--- a/docs/ml/comprehend/index.md
+++ b/docs/ml/comprehend/index.md
@@ -75,7 +75,7 @@ aws rds describe-db-clusters --db-cluster-identifier auroralab-mysql-cluster \
 
 ## 4. Run Comprehend inferences from Aurora
 
-Run the command below, replacing the ==[clusterEndpont]== placeholder with the cluster endpoint of your DB cluster to connect to the database:
+Run the command below, replacing the ==[clusterEndpoint]== placeholder with the cluster endpoint of your DB cluster to connect to the database:
 
 ```shell
 mysql -h[clusterEndpoint] -u$DBUSER -p"$DBPASS" mltest

--- a/docs/ml/sagemaker/index.md
+++ b/docs/ml/sagemaker/index.md
@@ -75,7 +75,7 @@ aws rds describe-db-clusters --db-cluster-identifier auroralab-mysql-cluster \
 
 ## 4. Create a SageMaker integration function in Aurora
 
-Run the command below, replacing the ==[clusterEndpont]== placeholder with the cluster endpoint of your DB cluster to connect to the database:
+Run the command below, replacing the ==[clusterEndpoint]== placeholder with the cluster endpoint of your DB cluster to connect to the database:
 
 ```shell
 mysql -h[clusterEndpoint] -u$DBUSER -p"$DBPASS" mltest

--- a/docs/provisioned/backtrack/index.md
+++ b/docs/provisioned/backtrack/index.md
@@ -43,7 +43,7 @@ Remember or save the time markers displayed by the commands above, you will use 
 
 <span class="image">![Drop Table](1-drop-table.png?raw=true)</span>
 
-Now, run the following command to replace the dropped table using the sysbench command, replacing the ==[clusterEndpont]== placeholder with the cluster endpoint of your DB cluster:
+Now, run the following command to replace the dropped table using the sysbench command, replacing the ==[clusterEndpoint]== placeholder with the cluster endpoint of your DB cluster:
 
 ```shell
 sysbench oltp_write_only \

--- a/docs/provisioned/create/index.md
+++ b/docs/provisioned/create/index.md
@@ -182,7 +182,7 @@ Next, in the **Select which RDS database this secret will access** section, choo
 
 <span class="image">![Configure Secret](5-config-secret.png?raw=true)</span>
 
-Name the secret `secretCusterMasterUser` and provide a relevant description for the secret, then click **Next**.
+Name the secret `secretClusterMasterUser` and provide a relevant description for the secret, then click **Next**.
 
 <span class="image">![Name Secret](5-name-secret.png?raw=true)</span>
 

--- a/docs/provisioned/failover/index.md
+++ b/docs/provisioned/failover/index.md
@@ -259,7 +259,7 @@ In the **Proxy configuration** section, set the Proxy identifier to `auroralab-m
 
 <span class="image">![Configure Proxy](5-config-proxy-target.png?raw=true)</span>
 
-In the **Connectivity** section, in the **Secret Manager secret(s)** dropdown, choose the secret with a name that starts with `secretCusterMasterUser`. In the **IAM role** dropdown, choose the option **Create IAM role**. Expand the **Additional connectivity options** section, and for **Existing VPC security groups** choose `auroralab-database-sg`.
+In the **Connectivity** section, in the **Secret Manager secret(s)** dropdown, choose the secret with a name that starts with `secretClusterMasterUser`. In the **IAM role** dropdown, choose the option **Create IAM role**. Expand the **Additional connectivity options** section, and for **Existing VPC security groups** choose `auroralab-database-sg`.
 
 <span class="image">![Configure Proxy Connectivity](5-config-connectivity.png?raw=true)</span>
 

--- a/docs/provisioned/interact/index.md
+++ b/docs/provisioned/interact/index.md
@@ -19,7 +19,7 @@ This lab requires the following prerequisites:
 
 Connect to the Aurora database just like you would to any other MySQL-based database, using a compatible client tool. In this lab you will be using the `mysql` command line tool to connect.
 
-If you are not already connected to the Session Manager workstation command line from previous labs, please connect [following these instructions](/prereqs/connect/). Once connected, run the command below, replacing the ==[clusterEndpont]== placeholder with the cluster endpoint of your DB cluster.
+If you are not already connected to the Session Manager workstation command line from previous labs, please connect [following these instructions](/prereqs/connect/). Once connected, run the command below, replacing the ==[clusterEndpoint]== placeholder with the cluster endpoint of your DB cluster.
 
 !!! tip "Where do I find the cluster endpoint (or any other placeholder parameters)?"
     If you have completed the previous lab, and created the Aurora DB cluster manually, you would find the value of the cluster endpoint on the DB cluster details page in the RDS console, as noted at Step 2. in that lab.


### PR DESCRIPTION
During deliver the lab (dry-run) i've seen a typo for `clusterEndpont` which is `clusterEndpoint`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
